### PR TITLE
Add numeric separators

### DIFF
--- a/syntax/javascript.vim
+++ b/syntax/javascript.vim
@@ -54,9 +54,9 @@ syntax match   jsModuleComma        contained /,/ skipwhite skipempty nextgroup=
 syntax region  jsString           start=+\z(["']\)+  skip=+\\\%(\z1\|$\)+  end=+\z1+ end=+$+  contains=jsSpecial extend
 syntax region  jsTemplateString   start=+`+  skip=+\\`+  end=+`+     contains=jsTemplateExpression,jsSpecial extend
 syntax match   jsTaggedTemplate   /\<\K\k*\ze`/ nextgroup=jsTemplateString
-syntax match   jsNumber           /\c\<\%(\d\+\%(e[+-]\=\d\+\)\=\|0b[01]\+\|0o\o\+\|0x\%(\x\|_\)\+\)\>/
+syntax match   jsNumber           /\c\<\%(\d\+\%(_\d\+\)\=\%(e[+-]\=\d\+\)\=\|0b[01]\+\%(_[01]\+\)\=\|0o\o\+\%(_\o\+\)\=\|0x\x\+\%(_\x\+\)\=\)\>/
 syntax keyword jsNumber           Infinity
-syntax match   jsFloat            /\c\<\%(\d\+\.\d\+\|\d\+\.\|\.\d\+\)\%(e[+-]\=\d\+\)\=\>/
+syntax match   jsFloat            /\c\<\%(\%(\d\+\%(_\d\+\)\=\)\=\.\%(\d\+\%(_\d\+\)\=\)\=\)\%(e[+-]\=\d\+\)\=\>/
 
 " Regular Expressions
 syntax match   jsSpecial            contained "\v\\%(x\x\x|u%(\x{4}|\{\x{4,5}})|c\u|.)"


### PR DESCRIPTION
Add syntax highlighting to numbers and floats with numeric separator as defined in [tc39/proposal-numeric-separator](https://github.com/tc39/proposal-numeric-separator).

```js
let fee = 123_00;       // $123 (12300 cents, apparently)
let fee = 12_300;       // $12,300 (woah, that fee!)
let amount = 12345_00;  // 12,345 (1234500 cents, apparently)
let amount = 123_4500;  // 123.45 (4-fixed financial)
let amount = 1_234_500; // 1,234,500

let millionth  = 0.000_001 // 1 millionth

let nibbles = 0b1010_0001_1000_0101;

let message = 0xA0_B0_C0;
```